### PR TITLE
Added migrate/create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ WIP
 ## Configuration
 
 Specify config file in `params` section for `composer-config-plugin`\
-[How to configure dbal connections](https://github.com/cycle/docs/blob/master/basic/connect.md)
+[How to configure DBAL connections](https://github.com/cycle/docs/blob/master/basic/connect.md)
 ```php
 <?php
 return [

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ WIP
 ## Configuration
 
 Specify config file in `params` section for `composer-config-plugin`\
-[How to configure connections](https://github.com/cycle/docs/blob/master/basic/connect.md)
+[How to configure dbal connections](https://github.com/cycle/docs/blob/master/basic/connect.md)
 ```php
 <?php
 return [
@@ -59,6 +59,7 @@ return [
 
 ```bash
 migrate/list
+migrate/create
 migrate/generate
 migrate/up
 migrate/down

--- a/config/console.php
+++ b/config/console.php
@@ -1,12 +1,9 @@
 <?php
 
-use App\Console\Command\CreateUser;
 use Yiisoft\Yii\Cycle\Factory\MigrationConfigFactory;
 use Yiisoft\Yii\Cycle\Factory\MigratorFactory;
-use Psr\Container\ContainerInterface;
 use Spiral\Migrations\Config\MigrationConfig;
 use Spiral\Migrations\Migrator;
-use Yiisoft\Aliases\Aliases;
 
 /**
  * @var array $params

--- a/config/params.php
+++ b/config/params.php
@@ -6,7 +6,7 @@ use Yiisoft\Yii\Cycle\Command;
 return [
     // Console commands
     'commands' => [
-        // 'migrate/create' => Command\CreateCommand::class,
+        'migrate/create' => Command\CreateCommand::class,
         'migrate/generate' => Command\GenerateCommand::class,
         'migrate/up' => Command\UpCommand::class,
         'migrate/down' => Command\DownCommand::class,

--- a/src/Command/BaseMigrationCommand.php
+++ b/src/Command/BaseMigrationCommand.php
@@ -46,7 +46,7 @@ abstract class BaseMigrationCommand extends Command
 
     protected function createEmptyMigration(OutputInterface $output, string $name, ?string $database = null): ?MigrationImage
     {
-        if (is_null($database)) {
+        if ($database === null) {
             // get default database
             $database = $this->dbal->database()->getName();
         }

--- a/src/Command/BaseMigrationCommand.php
+++ b/src/Command/BaseMigrationCommand.php
@@ -79,5 +79,4 @@ abstract class BaseMigrationCommand extends Command
         $output->writeln('<info>' . count($list) . ' migration(s) found in ' . $this->config->getDirectory() . '</info>');
         return $list;
     }
-
 }

--- a/src/Command/BaseMigrationCommand.php
+++ b/src/Command/BaseMigrationCommand.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Yiisoft\Yii\Cycle\Command;
+
+use Cycle\Migrations\MigrationImage;
+use Spiral\Database\DatabaseManager;
+use Spiral\Migrations\Config\MigrationConfig;
+use Spiral\Migrations\Exception\RepositoryException;
+use Spiral\Migrations\MigrationInterface;
+use Spiral\Migrations\Migrator;
+use Spiral\Migrations\State;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Yii\Cycle\Helper\CycleOrmHelper;
+
+abstract class BaseMigrationCommand extends Command
+{
+
+    /** @var DatabaseManager */
+    protected $dbal;
+    /** @var MigrationConfig */
+    protected $config;
+    /** @var Migrator */
+    protected $migrator;
+    /** @var CycleOrmHelper */
+    protected $cycleOrmHelper;
+
+    protected static $migrationStatus = [
+        State::STATUS_UNDEFINED => 'undefined',
+        State::STATUS_PENDING => 'pending',
+        State::STATUS_EXECUTED => 'executed',
+    ];
+
+    public function __construct(
+        DatabaseManager $dbal,
+        MigrationConfig $conf,
+        Migrator $migrator,
+        CycleOrmHelper $cycleOrmHelper
+    ) {
+        parent::__construct();
+        $this->dbal = $dbal;
+        $this->config = $conf;
+        $this->migrator = $migrator;
+        $this->cycleOrmHelper = $cycleOrmHelper;
+    }
+
+    protected function createEmptyMigration(OutputInterface $output, string $name, ?string $database = null): ?MigrationImage
+    {
+        if (is_null($database)) {
+            // get default database
+            $database = $this->dbal->database()->getName();
+        }
+
+        $migrationSkeleton = new MigrationImage($this->config, $database);
+        $migrationSkeleton->setName($name);
+        try {
+            $migrationFile = $this->migrator->getRepository()->registerMigration(
+                $migrationSkeleton->buildFileName(),
+                $migrationSkeleton->getClass()->getName(),
+                $migrationSkeleton->getFile()->render()
+            );
+        } catch (RepositoryException $e) {
+            $output->writeln('<fg=yellow>Can not create migration</>');
+            $output->writeln('<fg=red>' . $e->getMessage() . '</>');
+            return null;
+        }
+        $output->writeln('<info>New migration file has been created</info>');
+        $output->writeln("<fg=cyan>{$migrationFile}</>");
+        return $migrationSkeleton;
+    }
+
+    /**
+     * @param OutputInterface $output
+     * @return MigrationInterface[]
+     */
+    protected function findMigrations(OutputInterface $output): array
+    {
+        $list = $this->migrator->getMigrations();
+        $output->writeln('<info>' . count($list) . ' migration(s) found in ' . $this->config->getDirectory() . '</info>');
+        return $list;
+    }
+
+}

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -1,10 +1,15 @@
 <?php
 namespace Yiisoft\Yii\Cycle\Command;
 
+use Spiral\Database\DatabaseManager;
+use Spiral\Migrations\Exception\RepositoryException;
+use Spiral\Migrations\Migration;
 use Spiral\Migrations\Migrator;
 use Spiral\Migrations\Config\MigrationConfig;
-use Spiral\Migrations\State;
+use Spiral\Reactor\ClassDeclaration;
+use Spiral\Reactor\FileDeclaration;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Yiisoft\Yii\Cycle\Helper\CycleOrmHelper;
@@ -13,8 +18,8 @@ class CreateCommand extends Command
 {
     protected static $defaultName = 'migrate/create';
 
-    /** @var Migrator */
-    private $migrator;
+    /** @var DatabaseManager */
+    private $dbal;
 
     /** @var CycleOrmHelper */
     private $cycleHelper;
@@ -22,23 +27,62 @@ class CreateCommand extends Command
     /** @var MigrationConfig */
     private $config;
 
+    /** @var Migrator */
+    private $migrator;
+
     public function __construct(
-        Migrator $migrator,
+        DatabaseManager $dbal,
         MigrationConfig $conf,
-        CycleOrmHelper $cycleHelper
+        CycleOrmHelper $cycleHelper,
+        Migrator $migrator
     ) {
         parent::__construct();
-        $this->migrator = $migrator;
+        $this->dbal = $dbal;
         $this->config = $conf;
         $this->cycleHelper = $cycleHelper;
+        $this->migrator = $migrator;
     }
 
     public function configure(): void
     {
-        $this->setDescription('Create a migration');
+        $this->setDescription('Create a migration')
+             ->setHelp('This command allows you to create a custom migration')
+             ->addArgument('name', InputArgument::REQUIRED, 'Migration name');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
+        $customName = $input->getArgument('name');
+        $databaseName = $this->dbal->database()->getName();
+
+        // unique class name for the migration
+        $name = sprintf(
+            'orm_%s_%s',
+            $databaseName,
+            md5(microtime(true) . microtime(false))
+        );
+
+        $class = new ClassDeclaration($name, 'Migration');
+        $class->constant('DATABASE')->setProtected()->setValue($databaseName);
+        $class->method('up')->setPublic();
+        $class->method('down')->setPublic();
+
+        $file = new FileDeclaration($this->config->getNamespace());
+        $file->addUse(Migration::class);
+        $file->addElement($class);
+
+        $fileName = substr(sprintf('%s_%s', $databaseName, $customName), 0, 128);
+
+        try {
+            $migrationFile = $this->migrator->getRepository()
+                                            ->registerMigration($fileName, $class->getName(), $file->render());
+        } catch (RepositoryException $e) {
+            $output->writeln('<fg=yellow>Can not create migration</>');
+            $output->writeln('<fg=red>' . $e->getMessage() . '</>');
+            return;
+        }
+        $output->writeln('<info>' . basename($migrationFile) . ' has been created in '
+            . $this->config->getDirectory() . '</info>');
+
     }
 }

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -1,43 +1,17 @@
 <?php
 namespace Yiisoft\Yii\Cycle\Command;
 
-use Cycle\Migrations\MigrationImage;
-use Spiral\Database\DatabaseManager;
-use Spiral\Migrations\Exception\RepositoryException;
-use Spiral\Migrations\Migrator;
-use Spiral\Migrations\Config\MigrationConfig;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CreateCommand extends Command
+class CreateCommand extends BaseMigrationCommand
 {
     protected static $defaultName = 'migrate/create';
 
-    /** @var DatabaseManager */
-    private $dbal;
-
-    /** @var MigrationConfig */
-    private $config;
-
-    /** @var Migrator */
-    private $migrator;
-
-    public function __construct(
-        DatabaseManager $dbal,
-        MigrationConfig $conf,
-        Migrator $migrator
-    ) {
-        parent::__construct();
-        $this->dbal = $dbal;
-        $this->config = $conf;
-        $this->migrator = $migrator;
-    }
-
     public function configure(): void
     {
-        $this->setDescription('Create a migration')
+        $this->setDescription('Create an empty migration')
              ->setHelp('This command allows you to create a custom migration')
              ->addArgument('name', InputArgument::REQUIRED, 'Migration name');
     }
@@ -45,24 +19,7 @@ class CreateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $customName = $input->getArgument('name');
-        // get default database
-        $databaseName = $this->dbal->database()->getName();
 
-        $migrationSkeleton = new MigrationImage($this->config, $databaseName);
-        $migrationSkeleton->setName($customName);
-
-        try {
-            $migrationFile = $this->migrator->getRepository()->registerMigration(
-                $migrationSkeleton->buildFileName(),
-                $migrationSkeleton->getClass()->getName(),
-                $migrationSkeleton->getFile()->render()
-            );
-        } catch (RepositoryException $e) {
-            $output->writeln('<fg=yellow>Can not create migration</>');
-            $output->writeln('<fg=red>' . $e->getMessage() . '</>');
-            return;
-        }
-        $output->writeln('<info>New migration file has been created</info>');
-        $output->writeln("<fg=cyan>{$migrationFile}</>");
+        $this->createEmptyMigration($output, $customName);
     }
 }

--- a/src/Command/DownCommand.php
+++ b/src/Command/DownCommand.php
@@ -1,41 +1,13 @@
 <?php
 namespace Yiisoft\Yii\Cycle\Command;
 
-use Spiral\Migrations\Config\MigrationConfig;
 use Spiral\Migrations\MigrationInterface;
-use Spiral\Migrations\Migrator;
-use Spiral\Migrations\State;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Yiisoft\Yii\Cycle\Helper\CycleOrmHelper;
 
-class DownCommand extends Command
+class DownCommand extends BaseMigrationCommand
 {
     protected static $defaultName = 'migrate/down';
-
-    /** @var MigrationConfig */
-    private $config;
-
-    /** @var Migrator */
-    private $migrator;
-
-    /** @var CycleOrmHelper */
-    private $cycleOrmHelper;
-
-    /**
-     * MigrateGenerateCommand constructor.
-     * @param Migrator        $migrator
-     * @param MigrationConfig $conf
-     * @param CycleOrmHelper  $cycleOrmHelper
-     */
-    public function __construct(Migrator $migrator, MigrationConfig $conf, CycleOrmHelper $cycleOrmHelper)
-    {
-        parent::__construct();
-        $this->config = $conf;
-        $this->migrator = $migrator;
-        $this->cycleOrmHelper = $cycleOrmHelper;
-    }
 
     public function configure(): void
     {
@@ -48,14 +20,8 @@ class DownCommand extends Command
         // drop cached schema
         $this->cycleOrmHelper->dropCurrentSchemaCache();
 
-        $list = $this->migrator->getMigrations();
-        $output->writeln('<info>' . count($list) . ' migrations found in ' . $this->config->getDirectory() . '</info>');
+        $this->findMigrations($output);
 
-        $statuses = [
-            State::STATUS_UNDEFINED => 'undefined',
-            State::STATUS_PENDING => 'pending',
-            State::STATUS_EXECUTED => 'executed',
-        ];
         try {
             $migration = $this->migrator->rollback();
             if (!$migration instanceof MigrationInterface) {
@@ -64,7 +30,7 @@ class DownCommand extends Command
 
             $state = $migration->getState();
             $status = $state->getStatus();
-            $output->writeln($state->getName() . ': ' . ($statuses[$status] ?? $status));
+            $output->writeln('<fg=cyan>' . $state->getName() . '</>: ' . (static::$migrationStatus[$status] ?? $status));
         } catch (\Throwable $e) {
             $output->writeln([
                 '<fg=red>Error!</>',

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -5,6 +5,8 @@ use Spiral\Migrations\State;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
 use Yiisoft\Yii\Cycle\Generator\ShowChangesGenerator;
 
 class GenerateCommand extends BaseMigrationCommand
@@ -45,15 +47,18 @@ class GenerateCommand extends BaseMigrationCommand
         } else {
             $output->writeln('<info>If you want to create new empty migration, use <fg=yellow>migrate/create</></info>');
 
+
+            $qaHelper = $this->getHelper('question');
+
             if ($input->isInteractive() && $input instanceof StreamableInputInterface) {
-                $output->write('Would you like to create empty migration right now? (Y/n): ');
-                $answer = fgets($input->getStream() ?? STDIN);
-                if (!empty(trim($answer)) && !in_array(strtolower(trim($answer)), ['yes', 'y'])) {
+                $question = new ConfirmationQuestion('Would you like to create empty migration right now? (Y/n)', true);
+                $answer = $qaHelper->ask($input, $output, $question);
+                if (!$answer) {
                     return;
                 }
                 // get the name for a new migration
-                $output->write('Please enter an unique name for the new migration: ');
-                $name = trim(fgets($input->getStream() ?? STDIN));
+                $question = new Question('Please enter an unique name for the new migration: ');
+                $name = $qaHelper->ask($input, $output, $question);
                 if (empty($name)) {
                     $output->writeln('<fg=red>You entered an empty name. Exit</>');
                     return;

--- a/src/Command/ListCommand.php
+++ b/src/Command/ListCommand.php
@@ -1,32 +1,12 @@
 <?php
 namespace Yiisoft\Yii\Cycle\Command;
 
-use Spiral\Migrations\Config\MigrationConfig;
-use Spiral\Migrations\Migrator;
-use Spiral\Migrations\State;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListCommand extends Command
+class ListCommand extends BaseMigrationCommand
 {
     protected static $defaultName = 'migrate/list';
-
-    /** @var MigrationConfig */
-    private $config;
-    /** @var Migrator */
-    private $migrator;
-    /**
-     * MigrateGenerateCommand constructor.
-     * @param Migrator                 $migrator
-     * @param MigrationConfig   $conf
-     */
-    public function __construct(Migrator $migrator, MigrationConfig $conf)
-    {
-        $this->config = $conf;
-        $this->migrator = $migrator;
-        parent::__construct();
-    }
 
     public function configure(): void
     {
@@ -36,19 +16,12 @@ class ListCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $list = $this->migrator->getMigrations();
-        $output->writeln('<info>' . count($list) . ' migrations found in ' . $this->config->getDirectory() . '</info>');
-
-        $statuses = [
-            State::STATUS_UNDEFINED => 'undefined',
-            State::STATUS_PENDING => 'pending',
-            State::STATUS_EXECUTED => 'executed',
-        ];
-        $list = $this->migrator->getMigrations();
+        $list = $this->findMigrations($output);
 
         foreach ($list as $migration) {
             $state = $migration->getState();
-            $output->writeln($state->getName() . ' <fg=yellow>[' . ($statuses[$state->getStatus()] ?? '?') . ']</fg=yellow>');
+            $output->writeln('<fg=cyan>' . $state->getName() . '</> '
+                . '<fg=yellow>[' . (static::$migrationStatus[$state->getStatus()] ?? '?') . ']</>');
         }
     }
 }

--- a/src/Command/UpCommand.php
+++ b/src/Command/UpCommand.php
@@ -1,41 +1,13 @@
 <?php
 namespace Yiisoft\Yii\Cycle\Command;
 
-use Spiral\Migrations\Config\MigrationConfig;
 use Spiral\Migrations\MigrationInterface;
-use Spiral\Migrations\Migrator;
-use Spiral\Migrations\State;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Yiisoft\Yii\Cycle\Helper\CycleOrmHelper;
 
-class UpCommand extends Command
+class UpCommand extends BaseMigrationCommand
 {
     protected static $defaultName = 'migrate/up';
-
-    /** @var MigrationConfig */
-    private $config;
-
-    /** @var Migrator */
-    private $migrator;
-
-    /** @var CycleOrmHelper */
-    private $cycleOrmHelper;
-
-    /**
-     * MigrateGenerateCommand constructor.
-     * @param Migrator        $migrator
-     * @param MigrationConfig $conf
-     * @param CycleOrmHelper  $cycleOrmHelper
-     */
-    public function __construct(Migrator $migrator, MigrationConfig $conf, CycleOrmHelper $cycleOrmHelper)
-    {
-        parent::__construct();
-        $this->config = $conf;
-        $this->migrator = $migrator;
-        $this->cycleOrmHelper = $cycleOrmHelper;
-    }
 
     public function configure(): void
     {
@@ -48,15 +20,9 @@ class UpCommand extends Command
         // drop cached schema
         $this->cycleOrmHelper->dropCurrentSchemaCache();
 
-        $list = $this->migrator->getMigrations();
-        $output->writeln('<info>' . count($list) . ' migrations found in ' . $this->config->getDirectory() . '</info>');
+        $this->findMigrations($output);
 
         $limit = PHP_INT_MAX;
-        $statuses = [
-            State::STATUS_UNDEFINED => 'undefined',
-            State::STATUS_PENDING => 'pending',
-            State::STATUS_EXECUTED => 'executed',
-        ];
         try {
             do {
                 $migration = $this->migrator->run();
@@ -66,7 +32,8 @@ class UpCommand extends Command
 
                 $state = $migration->getState();
                 $status = $state->getStatus();
-                $output->writeln($state->getName() . ': ' . ($statuses[$status] ?? $status));
+                $output->writeln('<fg=cyan>' . $state->getName() . '</>: '
+                    . (static::$migrationStatus[$status] ?? $status));
             } while (--$limit > 0);
         } catch (\Throwable $e) {
             $output->writeln([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | 

Added `migrate/create` command. This command creates new empty migration with custom name

---

Added an interactive mode for creating empty migrations if no changes were detected during the automatic generation of migrations via `migrate/generate`:
![image](https://user-images.githubusercontent.com/4152481/69174765-81e87200-0b13-11ea-8b3b-c06e4ea9db45.png)
