### PR TITLE
Replace factory to injector for the CycleDynamicFactory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
         "psr/simple-cache": "^1.0",
         "yiisoft/aliases": "^1.0",
         "yiisoft/data": "@dev",
-        "yiisoft/factory": "^3.0@dev",
         "yiisoft/friendly-exception": "^1.0",
+        "yiisoft/injector": "^1.0.2",
         "yiisoft/yii-console": "@dev"
     },
     "require-dev": {

--- a/src/Factory/CycleDynamicFactory.php
+++ b/src/Factory/CycleDynamicFactory.php
@@ -4,13 +4,20 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Cycle\Factory;
 
+use Psr\Container\ContainerInterface;
 use Spiral\Core\FactoryInterface;
-use Yiisoft\Factory\Factory;
+use Yiisoft\Injector\Injector;
 
-final class CycleDynamicFactory extends Factory implements FactoryInterface
+final class CycleDynamicFactory implements FactoryInterface
 {
+    private Injector $injector;
+    public function __construct(ContainerInterface $container)
+    {
+        $this->injector = new Injector($container);
+    }
+
     public function make(string $alias, array $parameters = [])
     {
-        return $this->create($alias, $parameters);
+        return $this->injector->make($alias, $parameters);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Factory dependency is redundant when Injector functionality suffices.
In addition, the Injector is currently more stable. Factory causes a bug when saving embeddable entities