### PR TITLE
Add repository provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
             "params": "config/params.php",
             "common": "config/common.php",
             "console": "config/console.php",
-            "events-console": "config/events-console.php"
+            "events-console": "config/events-console.php",
+            "providers-web": "config/providers-web.php"
         }
     },
     "scripts": {

--- a/config/providers-web.php
+++ b/config/providers-web.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'yiisoft/cycle-orm/repository-provider' => \Yiisoft\Yii\Cycle\Factory\RepositoryProvider::class,
+];

--- a/config/providers-web.php
+++ b/config/providers-web.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 return [
     'yiisoft/cycle-orm/repository-provider' => \Yiisoft\Yii\Cycle\Factory\RepositoryProvider::class,
 ];

--- a/src/Factory/RepositoryProvider.php
+++ b/src/Factory/RepositoryProvider.php
@@ -11,6 +11,8 @@ use Cycle\ORM\SchemaInterface;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\Support\ServiceProvider;
 
+use function is_string;
+
 final class RepositoryProvider extends ServiceProvider
 {
     public function register(Container $container): void

--- a/src/Factory/RepositoryProvider.php
+++ b/src/Factory/RepositoryProvider.php
@@ -13,6 +13,10 @@ use Yiisoft\Di\Support\ServiceProvider;
 
 use function is_string;
 
+/**
+ * This provider provides factories to the container for creating Cycle entity repositories.
+ * Repository list is compiled based on data from the database schema.
+ */
 final class RepositoryProvider extends ServiceProvider
 {
     public function register(Container $container): void

--- a/src/Factory/RepositoryProvider.php
+++ b/src/Factory/RepositoryProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Factory;
+
+use Closure;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\RepositoryInterface;
+use Cycle\ORM\SchemaInterface;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\Support\ServiceProvider;
+
+final class RepositoryProvider extends ServiceProvider
+{
+    public function register(Container $container): void
+    {
+        /** @var ORMInterface */
+        $orm = $container->get(ORMInterface::class);
+        /** @psalm-suppress InaccessibleMethod */
+        $container->setMultiple($this->getRepositoryFactories($orm));
+    }
+
+    /**
+     * @return array<string, Closure> Repository name as key and factory as value
+     */
+    private function getRepositoryFactories(ORMInterface $orm): array
+    {
+        $schema = $orm->getSchema();
+        $result = [];
+        $roles = [];
+        foreach ($schema->getRoles() as $role) {
+            $repository = $schema->define($role, SchemaInterface::REPOSITORY);
+            if (is_string($repository)) {
+                $roles[$repository][] = $role;
+            }
+        }
+        foreach ($roles as $repo => $role) {
+            if (count($role) === 1) {
+                $result[$repo] = $this->makeRepositoryFactory($orm, current($role));
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    private function makeRepositoryFactory(ORMInterface $orm, string $role): Closure
+    {
+        return static fn (): RepositoryInterface => $orm->getRepository($role);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #20 

Added the repository provider that automatically makes a list of repositories from the DB schema.
This provider added into `providers-web` config group.

After merge you can remove the [RepositoryProvider](https://github.com/yiisoft/yii-demo/blob/8adf29f128747b502c751ee28feb6f0d6dcc6b95/src/Provider/RepositoryProvider.php)