### PR TITLE
Update EntityReader.php

### DIFF
--- a/src/Data/Reader/EntityReader.php
+++ b/src/Data/Reader/EntityReader.php
@@ -60,7 +60,7 @@ final class EntityReader implements DataReaderInterface
     /**
      * @psalm-mutation-free
      */
-    public function withLimit(int $limit): self
+    public function withLimit(int $limit): static
     {
         if ($limit < 0) {
             throw new InvalidArgumentException('$limit must not be less than 0.');
@@ -76,7 +76,7 @@ final class EntityReader implements DataReaderInterface
     /**
      * @psalm-mutation-free
      */
-    public function withOffset(int $offset): self
+    public function withOffset(int $offset): static
     {
         $new = clone $this;
         if ($new->offset !== $offset) {
@@ -89,7 +89,7 @@ final class EntityReader implements DataReaderInterface
     /**
      * @psalm-mutation-free
      */
-    public function withSort(?Sort $sort): self
+    public function withSort(?Sort $sort): static
     {
         $new = clone $this;
         if ($new->sorting !== $sort) {
@@ -103,7 +103,7 @@ final class EntityReader implements DataReaderInterface
     /**
      * @psalm-mutation-free
      */
-    public function withFilter(FilterInterface $filter): self
+    public function withFilter(FilterInterface $filter): static
     {
         $new = clone $this;
         if ($new->filter !== $filter) {
@@ -146,7 +146,7 @@ final class EntityReader implements DataReaderInterface
     /**
      * @return mixed
      */
-    public function readOne()
+    public function readOne() : array|object|null
     {
         if (!$this->oneItemCache->isCollected()) {
             $item = $this->itemsCache->isCollected()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

I am getting the following error which resolves with the following code. Refer to the following issue:
[Issue 559](https://github.com/yiisoft/demo/issues/559) from rossaddion/yii3-i implementation.

PHP Compile Error — Yiisoft\ErrorHandler\Exception\ErrorException
Declaration of Yiisoft\Yii\Cycle\Data\Reader\EntityReader::withLimit(int $limit): Yiisoft\Yii\Cycle\Data\Reader\EntityReader must be compatible with Yiisoft\Data\Reader\ReadableDataInterface::withLimit(int $limit): Composer\Autoload\ClassLoader
