### PR TITLE
Write test for Command

### DIFF
--- a/tests/Command/Schema/SchemaClearBaseCommandTest.php
+++ b/tests/Command/Schema/SchemaClearBaseCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Schema;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Schema\SchemaClearCommand;
+use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
+
+class SchemaClearBaseCommandTest extends \PHPUnit\Framework\TestCase
+{
+    public function testExecute(): void
+    {
+        $schemaProvider = $this->getMockBuilder(SchemaProviderInterface::class)->getMock();
+        $schemaProvider->expects($this->once())->method('clear');
+        $container = new SimpleContainer([SchemaProviderInterface::class => $schemaProvider]);
+        $promise = new CycleDependencyProxy($container);
+        $command = new SchemaClearCommand($promise);
+        $input = $this->getMockBuilder(InputInterface::class)->getMock();
+        $output = $this->getMockBuilder(OutputInterface::class)->getMock();
+
+        $code = $command->run($input, $output);
+
+        $this->assertEquals(ExitCode::OK, $code);
+    }
+
+    protected function getContainerDefinitions(): array
+    {
+        $schemaProvider = $this->getMockBuilder(SchemaProviderInterface::class)->getMock();
+        $schemaProvider->expects($this->once())->method('clear');
+
+        return [SchemaProviderInterface::class => $schemaProvider];
+    }
+}

--- a/tests/Command/Schema/SchemaClearBaseCommandTest.php
+++ b/tests/Command/Schema/SchemaClearBaseCommandTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
 use Yiisoft\Yii\Cycle\Command\Schema\SchemaClearCommand;
 use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
 
-class SchemaClearBaseCommandTest extends TestCase
+final class SchemaClearBaseCommandTest extends TestCase
 {
     public function testExecute(): void
     {

--- a/tests/Command/Schema/SchemaClearBaseCommandTest.php
+++ b/tests/Command/Schema/SchemaClearBaseCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Cycle\Tests\Command\Schema;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Yiisoft\Test\Support\Container\SimpleContainer;
@@ -12,7 +13,7 @@ use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
 use Yiisoft\Yii\Cycle\Command\Schema\SchemaClearCommand;
 use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
 
-class SchemaClearBaseCommandTest extends \PHPUnit\Framework\TestCase
+class SchemaClearBaseCommandTest extends TestCase
 {
     public function testExecute(): void
     {
@@ -27,13 +28,5 @@ class SchemaClearBaseCommandTest extends \PHPUnit\Framework\TestCase
         $code = $command->run($input, $output);
 
         $this->assertEquals(ExitCode::OK, $code);
-    }
-
-    protected function getContainerDefinitions(): array
-    {
-        $schemaProvider = $this->getMockBuilder(SchemaProviderInterface::class)->getMock();
-        $schemaProvider->expects($this->once())->method('clear');
-
-        return [SchemaProviderInterface::class => $schemaProvider];
     }
 }

--- a/tests/Command/Schema/SchemaCommandTest.php
+++ b/tests/Command/Schema/SchemaCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Schema;
+
+use Cycle\ORM\SchemaInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Schema\SchemaCommand;
+
+class SchemaCommandTest extends TestCase
+{
+    private OutputInterface $output;
+
+    protected function setUp(): void
+    {
+        $this->output = new class extends Output {
+            private string $buffer = '';
+
+            protected function doWrite(string $message, bool $newline): void
+            {
+                $this->buffer .= $message;
+
+                if ($newline) {
+                    $this->buffer .= \PHP_EOL;
+                }
+            }
+
+            public function getBuffer(): string
+            {
+                return $this->buffer;
+            }
+        };
+    }
+
+    public function testExecuteUndefinedRoles(): void
+    {
+        $schema = $this->getMockBuilder(SchemaInterface::class)->getMock();
+        $schema->expects($this->any())->method('getRoles')->willReturn([]);
+
+        $container = new SimpleContainer([SchemaInterface::class => $schema]);
+        $promise = new CycleDependencyProxy($container);
+        $command = new SchemaCommand($promise);
+
+        $code = $command->run(new ArrayInput(['role' => 'foo,bar']), $this->output);
+
+        $this->assertEquals(ExitCode::OK, $code);
+        $this->assertStringContainsString('Undefined roles: foo, bar', $this->output->getBuffer());
+    }
+
+    public function testExecuteGetRoles(): void
+    {
+        $schema = $this->getMockBuilder(SchemaInterface::class)->getMock();
+        $schema->expects($this->any())->method('getRoles')->willReturn(['foo', 'bar']);
+        $schema->expects($this->any())->method('define')->willReturnCallback(
+            function (string $role, int $property) {
+                if ($property === SchemaInterface::ROLE) {
+                    return $role;
+                }
+
+                return null;
+            }
+        );
+
+        $container = new SimpleContainer([SchemaInterface::class => $schema]);
+        $promise = new CycleDependencyProxy($container);
+        $command = new SchemaCommand($promise);
+
+        $code = $command->run(new ArrayInput([]), $this->output);
+
+        $this->assertEquals(ExitCode::OK, $code);
+        $this->assertStringNotContainsString('Undefined roles', $this->output->getBuffer());
+    }
+}

--- a/tests/Command/Schema/SchemaCommandTest.php
+++ b/tests/Command/Schema/SchemaCommandTest.php
@@ -14,7 +14,7 @@ use Yiisoft\Yii\Console\ExitCode;
 use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
 use Yiisoft\Yii\Cycle\Command\Schema\SchemaCommand;
 
-class SchemaCommandTest extends TestCase
+final class SchemaCommandTest extends TestCase
 {
     private OutputInterface $output;
 

--- a/tests/Command/Schema/SchemaRebuildCommandTest.php
+++ b/tests/Command/Schema/SchemaRebuildCommandTest.php
@@ -11,7 +11,7 @@ use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
 use Yiisoft\Yii\Cycle\Command\Schema\SchemaRebuildCommand;
 use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
 
-class SchemaRebuildCommandTest extends TestCase
+final class SchemaRebuildCommandTest extends TestCase
 {
     public function testExecute()
     {

--- a/tests/Command/Schema/SchemaRebuildCommandTest.php
+++ b/tests/Command/Schema/SchemaRebuildCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Schema\SchemaRebuildCommand;
+use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
+
+class SchemaRebuildCommandTest extends TestCase
+{
+    public function testExecute()
+    {
+        $provider = $this->getMockBuilder(SchemaProviderInterface::class)->getMock();
+        $provider->expects($this->once())->method('clear');
+        $provider->expects($this->once())->method('read');
+
+        $container = new SimpleContainer([SchemaProviderInterface::class => $provider]);
+        $promise = new CycleDependencyProxy($container);
+
+        $command = new SchemaRebuildCommand($promise);
+
+        $code = $command->run(new ArrayInput([]), new BufferedOutput);
+
+        $this->assertEquals(ExitCode::OK, $code);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

In Symfony command property  $defaultName and $defaultDescription is deprecated. Сan i fix it?