### PR TITLE
Deprecate `AnnotatedSchemaConveyor` and `CompositeSchemaConveyor`

### DIFF
--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -13,6 +13,7 @@ If you use Yii with `composer-config-plugin`, Yii-Cycle settings could be specif
 ```php
 <?php
 use Cycle\Schema\Generator;
+use Yiisoft\Yii\Cycle\Schema\Conveyor\AttributedSchemaConveyor;
 
 return [
     // Common Cycle config
@@ -76,9 +77,9 @@ return [
         /**
          * {@see \Yiisoft\Yii\Cycle\Schema\Conveyor\SchemaConveyorInterface} implementation class name.
          * That implementation defines the entity data source: annotations, attributes or both.
-         * Can be `AnnotatedSchemaConveyor`, `AttributedSchemaConveyor` or `CompositeSchemaConveyor`
+         * Can be `AttributedSchemaConveyor`, `AnnotatedSchemaConveyor` or `CompositeSchemaConveyor`
          */
-        'conveyor-class' => CompositedSchemaConveyor::class,
+        'conveyor-class' => AttributedSchemaConveyor::class,
     ],
 ];
 ```

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -13,6 +13,7 @@ Si utiliza `yiisoft/config`, la configuración de `yisoft/yii-cycle` se debe esp
 ```php
 <?php
 use Cycle\Schema\Generator;
+use Yiisoft\Yii\Cycle\Schema\Conveyor\AttributedSchemaConveyor;
 
 return [
     // Configuración de Cycle común
@@ -76,9 +77,9 @@ return [
         /**
          * {@see \Yiisoft\Yii\Cycle\Schema\Conveyor\SchemaConveyorInterface} Implementación del class name.
          * Esa implementación define la fuente de datos de la entidad: anotaciones, atributos o ambos.
-         * Pueden ser `AnnotatedSchemaConveyor`, `AttributedSchemaConveyor` o `CompositeSchemaConveyor`
+         * Pueden ser `AttributedSchemaConveyor`, `AnnotatedSchemaConveyor` o `CompositeSchemaConveyor`
          */
-        'conveyor-class' => CompositedSchemaConveyor::class,
+        'conveyor-class' => AttributedSchemaConveyor::class,
     ],
 ];
 ```

--- a/docs/ru/installation.md
+++ b/docs/ru/installation.md
@@ -14,6 +14,7 @@ composer require yiisoft/yii-cycle "2.0.x-dev"
 ```php
 <?php
 use Cycle\Schema\Generator;
+use Yiisoft\Yii\Cycle\Schema\Conveyor\AttributedSchemaConveyor;
 
 return [
     // Общий конфиг Cycle
@@ -78,11 +79,11 @@ return [
         /**
          * Реализация интерфейса {@see \Yiisoft\Yii\Cycle\Schema\Conveyor\SchemaConveyorInterface},
          * определяющая источник данных о сущностях:
-         *  - `AnnotatedSchemaConveyor` - парсинг только аннотаций;
          *  - `AttributedSchemaConveyor` - парсинг только атрибутов (в том числе и на PHP 7.4);
+         *  - `AnnotatedSchemaConveyor` - парсинг только аннотаций;
          *  - `CompositeSchemaConveyor` - парсинг и аннотаций, и атрибутов.
          */
-        'conveyor-class' => CompositedSchemaConveyor::class,
+        'conveyor-class' => AttributedSchemaConveyor::class,
     ],
 ];
 ```

--- a/src/Schema/Conveyor/AnnotatedSchemaConveyor.php
+++ b/src/Schema/Conveyor/AnnotatedSchemaConveyor.php
@@ -6,6 +6,11 @@ namespace Yiisoft\Yii\Cycle\Schema\Conveyor;
 
 use Spiral\Attributes\AnnotationReader;
 
+/**
+ * @deprecated Use {@see AttributedSchemaConveyor} instead.
+ *
+ * @psalm-suppress DeprecatedClass
+ */
 final class AnnotatedSchemaConveyor extends MetadataSchemaConveyor
 {
     protected function getMetadataReader(): AnnotationReader

--- a/src/Schema/Conveyor/CompositeSchemaConveyor.php
+++ b/src/Schema/Conveyor/CompositeSchemaConveyor.php
@@ -9,6 +9,11 @@ use Spiral\Attributes\AttributeReader;
 use Spiral\Attributes\Composite\SelectiveReader;
 use Spiral\Attributes\ReaderInterface;
 
+/**
+ * @deprecated Use {@see AttributedSchemaConveyor} instead.
+ *
+ * @psalm-suppress DeprecatedClass
+ */
 final class CompositeSchemaConveyor extends MetadataSchemaConveyor
 {
     protected function getMetadataReader(): ?ReaderInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌


Starting from version **spiral/attributes** v3.1.3, AnnotationReader is marked as deprecated in favor of AttributeReader:
https://github.com/spiral/attributes/pull/13

Therefore, **Yiisoft\Yii\Cycle\Schema\Conveyor\AnnotatedSchemaConveyor** and **Yiisoft\Yii\Cycle\Schema\Conveyor\CompositeSchemaConveyor**, which use it, are marked as deprecated. The documentation has been corrected to show the use of **Yiisoft\Yii\Cycle\Schema\Conveyor\AttributedSchemaConveyor** by default.
