### PR TITLE
Add unit tests

### DIFF
--- a/src/Command/Migration/DownCommand.php
+++ b/src/Command/Migration/DownCommand.php
@@ -35,7 +35,6 @@ final class DownCommand extends BaseMigrationCommand
         // check any executed migration
         foreach (array_reverse($migrations) as $migration) {
             if ($migration->getState()->getStatus() === State::STATUS_EXECUTED) {
-                $exist = true;
                 break;
             }
         }
@@ -62,7 +61,7 @@ final class DownCommand extends BaseMigrationCommand
 
         $this->eventDispatcher->dispatch(new BeforeMigrate());
         try {
-            $migrator->rollback();
+            $migration = $migrator->rollback();
             if (!$migration instanceof MigrationInterface) {
                 throw new \Exception('Migration not found');
             }

--- a/src/Command/Migration/GenerateCommand.php
+++ b/src/Command/Migration/GenerateCommand.php
@@ -63,10 +63,10 @@ final class GenerateCommand extends BaseMigrationCommand
                 '<info>If you want to create new empty migration, use <fg=yellow>migrate/create</></info>'
             );
 
-            /** @var QuestionHelper $qaHelper */
-            $qaHelper = $this->getHelper('question');
-
             if ($input->isInteractive() && $input instanceof StreamableInputInterface) {
+                /** @var QuestionHelper $qaHelper */
+                $qaHelper = $this->getHelper('question');
+
                 $question = new ConfirmationQuestion('Would you like to create empty migration right now? (Y/n)', true);
                 $answer = $qaHelper->ask($input, $output, $question);
                 if (!$answer) {

--- a/src/Factory/RepositoryContainer.php
+++ b/src/Factory/RepositoryContainer.php
@@ -15,7 +15,6 @@ use function is_string;
 
 final class RepositoryContainer implements ContainerInterface
 {
-    private ContainerInterface $rootContainer;
     private ORMInterface $orm;
 
     private bool $rolesBuilt = false;
@@ -25,7 +24,6 @@ final class RepositoryContainer implements ContainerInterface
 
     public function __construct(ContainerInterface $rootContainer)
     {
-        $this->rootContainer = $rootContainer;
         $this->orm = $rootContainer->get(ORMInterface::class);
     }
 

--- a/tests/Command/CycleDependencyProxyTest.php
+++ b/tests/Command/CycleDependencyProxyTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command;
+
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\SchemaInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Schema\SchemaConveyorInterface;
+use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
+
+final class CycleDependencyProxyTest extends TestCase
+{
+    public function testGetDatabaseProvider(): void
+    {
+        $databaseProvider = $this->createMock(DatabaseProviderInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(DatabaseProviderInterface::class)
+            ->willReturn($databaseProvider);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($databaseProvider, $proxy->getDatabaseProvider());
+    }
+
+    public function testGetMigrationConfig(): void
+    {
+        $config = new MigrationConfig();
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(MigrationConfig::class)
+            ->willReturn($config);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($config, $proxy->getMigrationConfig());
+    }
+
+    public function testGetMigrator(): void
+    {
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            $this->createMock(DatabaseProviderInterface::class),
+            $this->createMock(RepositoryInterface::class)
+        );
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(Migrator::class)
+            ->willReturn($migrator);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($migrator, $proxy->getMigrator());
+    }
+
+    public function testGetOrm(): void
+    {
+        $orm = $this->createMock(ORMInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(ORMInterface::class)
+            ->willReturn($orm);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($orm, $proxy->getORM());
+    }
+
+    public function testGetSchema(): void
+    {
+        $schema = $this->createMock(SchemaInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(SchemaInterface::class)
+            ->willReturn($schema);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($schema, $proxy->getSchema());
+    }
+
+    public function testGetSchemaProvider(): void
+    {
+        $schemaProvider = $this->createMock(SchemaProviderInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(SchemaProviderInterface::class)
+            ->willReturn($schemaProvider);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($schemaProvider, $proxy->getSchemaProvider());
+    }
+
+    public function testGetSchemaConveyor(): void
+    {
+        $schemaConveyor = $this->createMock(SchemaConveyorInterface::class);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with(SchemaConveyorInterface::class)
+            ->willReturn($schemaConveyor);
+
+        $proxy = new CycleDependencyProxy($container);
+
+        $this->assertSame($schemaConveyor, $proxy->getSchemaConveyor());
+    }
+}

--- a/tests/Command/Migration/CreateCommandTest.php
+++ b/tests/Command/Migration/CreateCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Migration;
+
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Migration\CreateCommand;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeOutput;
+
+final class CreateCommandTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $config = new MigrationConfig(['namespace' => 'Test\\Migration']);
+
+        $database = $this->createMock(DatabaseInterface::class);
+        $database->expects($this->once())->method('getName')->willReturn('testDatabase');
+
+        $databaseProvider = $this->createMock(DatabaseProviderInterface::class);
+        $databaseProvider->expects($this->once())->method('database')->willReturn($database);
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository
+            ->expects($this->once())
+            ->method('registerMigration')
+            ->with(
+                'testDatabase_foo',
+                $this->callback(static fn (string $name): bool => \str_contains($name, 'OrmTestDatabase')),
+                $this->callback(static fn (string $name): bool =>
+                    \str_contains($name, 'OrmTestDatabase') &&
+                    \str_contains($name, 'namespace Test\\Migration') &&
+                    \str_contains($name, 'use Cycle\\Migrations\\Migration') &&
+                    \str_contains($name, 'protected const DATABASE = \'testDatabase\'') &&
+                    \str_contains($name, 'public function up(): void') &&
+                    \str_contains($name, 'public function down(): void')
+                )
+            );
+
+        $command = new CreateCommand(new CycleDependencyProxy(new SimpleContainer([
+            DatabaseProviderInterface::class => $databaseProvider,
+            Migrator::class => new Migrator(
+                $config,
+                $this->createMock(DatabaseProviderInterface::class),
+                $repository
+            ),
+            MigrationConfig::class => $config,
+        ])));
+
+        $output = new FakeOutput();
+        $code = $command->run(new ArrayInput(['name' => 'foo']), $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('New migration file has been created', $output->getBuffer());
+    }
+}

--- a/tests/Command/Migration/CreateCommandTest.php
+++ b/tests/Command/Migration/CreateCommandTest.php
@@ -36,7 +36,8 @@ final class CreateCommandTest extends TestCase
             ->with(
                 'testDatabase_foo',
                 $this->callback(static fn (string $name): bool => \str_contains($name, 'OrmTestDatabase')),
-                $this->callback(static fn (string $name): bool =>
+                $this->callback(
+                    static fn (string $name): bool =>
                     \str_contains($name, 'OrmTestDatabase') &&
                     \str_contains($name, 'namespace Test\\Migration') &&
                     \str_contains($name, 'use Cycle\\Migrations\\Migration') &&

--- a/tests/Command/Migration/DownCommandTest.php
+++ b/tests/Command/Migration/DownCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Migration;
+
+use Cycle\Database\Config\DatabaseConfig;
+use Cycle\Database\Config\SQLite\MemoryConnectionConfig;
+use Cycle\Database\Config\SQLiteDriverConfig;
+use Cycle\Database\DatabaseManager;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use Cycle\Migrations\State;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Migration\DownCommand;
+use Yiisoft\Yii\Cycle\Command\Migration\UpCommand;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeMigration;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeOutput;
+
+final class DownCommandTest extends TestCase
+{
+    public function testExecuteWithoutMigrations(): void
+    {
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->once())->method('getMigrations')->willReturn([]);
+
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            $this->createMock(DatabaseProviderInterface::class),
+            $repository
+        );
+
+        $output = new FakeOutput();
+        $command = new DownCommand(
+            new CycleDependencyProxy(new SimpleContainer([
+                Migrator::class => $migrator,
+                MigrationConfig::class => new MigrationConfig(),
+            ])),
+            $this->createMock(EventDispatcherInterface::class)
+        );
+        $code = $command->run(new ArrayInput([]), $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('No migration found for rollback', $output->getBuffer());
+    }
+
+    public function testExecute(): void
+    {
+        $migration = new FakeMigration();
+        $migration = $migration->withState(new State('test', new \DateTimeImmutable(), State::STATUS_PENDING));
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->exactly(5))->method('getMigrations')->willReturn([$migration]);
+
+        $db = new DatabaseManager(new DatabaseConfig([
+            'default' => 'default',
+            'databases' => ['default' => ['connection' => 'sqlite']],
+            'connections' => [
+                'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+            ],
+        ]));
+
+        $migrator = new Migrator(new MigrationConfig(), $db, $repository);
+        $migrator->configure();
+
+        $promise = new CycleDependencyProxy(new SimpleContainer([
+            DatabaseProviderInterface::class => $db,
+            Migrator::class => $migrator,
+            MigrationConfig::class => new MigrationConfig(),
+        ]));
+
+        $input = new ArrayInput([]);
+        $input->setInteractive(false);
+
+        $command = new UpCommand($promise, $this->createMock(EventDispatcherInterface::class));
+        $command->run($input, new NullOutput());
+
+        $command = new DownCommand($promise, $this->createMock(EventDispatcherInterface::class));
+        $output = new FakeOutput();
+        $code = $command->run($input, $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Total 1 migration(s) found', $output->getBuffer());
+        $this->assertStringContainsString('test: pending', $output->getBuffer());
+    }
+}

--- a/tests/Command/Migration/GenerateCommandTest.php
+++ b/tests/Command/Migration/GenerateCommandTest.php
@@ -40,8 +40,10 @@ final class GenerateCommandTest extends TestCase
                 'databases' => ['default' => ['connection' => 'sqlite']],
                 'connections' => [
                     'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
-                ]
-            ])), $repository);
+                ],
+            ])),
+            $repository
+        );
         $migrator->configure();
 
         $output = new FakeOutput();
@@ -67,8 +69,10 @@ final class GenerateCommandTest extends TestCase
                 'databases' => ['default' => ['connection' => 'sqlite']],
                 'connections' => [
                     'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
-                ]
-            ])), $repository);
+                ],
+            ])),
+            $repository
+        );
         $migrator->configure();
 
         $output = new FakeOutput();
@@ -109,8 +113,10 @@ final class GenerateCommandTest extends TestCase
                 'databases' => ['default' => ['connection' => 'sqlite']],
                 'connections' => [
                     'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
-                ]
-            ])), $repository);
+                ],
+            ])),
+            $repository
+        );
         $migrator->configure();
 
         $output = new FakeOutput();

--- a/tests/Command/Migration/GenerateCommandTest.php
+++ b/tests/Command/Migration/GenerateCommandTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Migration;
+
+use Cycle\Database\Config\DatabaseConfig;
+use Cycle\Database\Config\SQLite\MemoryConnectionConfig;
+use Cycle\Database\Config\SQLiteDriverConfig;
+use Cycle\Database\DatabaseManager;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use Cycle\Migrations\State;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Migration\GenerateCommand;
+use Yiisoft\Yii\Cycle\Schema\SchemaConveyorInterface;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeMigration;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeOutput;
+
+final class GenerateCommandTest extends TestCase
+{
+    public function testExecuteWithOutstandingMigrations(): void
+    {
+        $migration = new FakeMigration();
+        $migration = $migration->withState(new State('test', new \DateTimeImmutable(), State::STATUS_PENDING));
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->exactly(1))->method('getMigrations')->willReturn([$migration]);
+
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            new DatabaseManager(new DatabaseConfig([
+                'default' => 'default',
+                'databases' => ['default' => ['connection' => 'sqlite']],
+                'connections' => [
+                    'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+                ]
+            ])), $repository);
+        $migrator->configure();
+
+        $output = new FakeOutput();
+        $command = new GenerateCommand(new CycleDependencyProxy(new SimpleContainer([
+            Migrator::class => $migrator,
+            MigrationConfig::class => new MigrationConfig(),
+        ])));
+        $code = $command->run(new ArrayInput([]), $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Outstanding migrations found, run `migrate/up` first.', $output->getBuffer());
+    }
+
+    public function testExecuteWithoutChanges(): void
+    {
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->exactly(2))->method('getMigrations')->willReturn([]);
+
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            new DatabaseManager(new DatabaseConfig([
+                'default' => 'default',
+                'databases' => ['default' => ['connection' => 'sqlite']],
+                'connections' => [
+                    'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+                ]
+            ])), $repository);
+        $migrator->configure();
+
+        $output = new FakeOutput();
+        $command = new GenerateCommand(new CycleDependencyProxy(new SimpleContainer([
+            Migrator::class => $migrator,
+            MigrationConfig::class => new MigrationConfig(),
+            SchemaConveyorInterface::class => $this->createMock(SchemaConveyorInterface::class),
+            DatabaseProviderInterface::class => $this->createMock(DatabaseProviderInterface::class),
+        ])));
+
+        $input = new ArrayInput([]);
+        $input->setInteractive(false);
+        $code = $command->run($input, $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Added 0 file(s)', $output->getBuffer());
+        $this->assertStringContainsString(
+            'If you want to create new empty migration, use migrate/create',
+            $output->getBuffer()
+        );
+    }
+
+    public function testExecute(): void
+    {
+        $migration = new FakeMigration();
+        $migration = $migration->withState(new State('test', new \DateTimeImmutable(), State::STATUS_PENDING));
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->exactly(2))->method('getMigrations')->willReturnOnConsecutiveCalls(
+            [],
+            [$migration]
+        );
+
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            new DatabaseManager(new DatabaseConfig([
+                'default' => 'default',
+                'databases' => ['default' => ['connection' => 'sqlite']],
+                'connections' => [
+                    'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+                ]
+            ])), $repository);
+        $migrator->configure();
+
+        $output = new FakeOutput();
+        $command = new GenerateCommand(new CycleDependencyProxy(new SimpleContainer([
+            Migrator::class => $migrator,
+            MigrationConfig::class => new MigrationConfig(),
+            SchemaConveyorInterface::class => $this->createMock(SchemaConveyorInterface::class),
+            DatabaseProviderInterface::class => $this->createMock(DatabaseProviderInterface::class),
+        ])));
+
+        $input = new ArrayInput([]);
+        $input->setInteractive(false);
+        $code = $command->run($input, $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Added 1 file(s)', $output->getBuffer());
+        $this->assertStringContainsString('test', $output->getBuffer());
+    }
+}

--- a/tests/Command/Migration/ListCommandTest.php
+++ b/tests/Command/Migration/ListCommandTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Migration;
+
+use Cycle\Database\Config\DatabaseConfig;
+use Cycle\Database\Config\SQLite\MemoryConnectionConfig;
+use Cycle\Database\Config\SQLiteDriverConfig;
+use Cycle\Database\DatabaseManager;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use Cycle\Migrations\State;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Migration\ListCommand;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeMigration;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeOutput;
+
+final class ListCommandTest extends TestCase
+{
+    public function testExecute(): void
+    {
+        $migration = new FakeMigration();
+        $migration = $migration->withState(new State('test', new \DateTimeImmutable(), State::STATUS_PENDING));
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->exactly(1))->method('getMigrations')->willReturn([$migration]);
+
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            new DatabaseManager(new DatabaseConfig([
+                'default' => 'default',
+                'databases' => ['default' => ['connection' => 'sqlite']],
+                'connections' => [
+                    'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+                ],
+            ])),
+            $repository
+        );
+        $migrator->configure();
+
+        $output = new FakeOutput();
+        $command = new ListCommand(
+            new CycleDependencyProxy(new SimpleContainer([
+                Migrator::class => $migrator,
+                MigrationConfig::class => new MigrationConfig(),
+            ])),
+        );
+        $code = $command->run(new ArrayInput([]), $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Total 1 migration(s) found', $output->getBuffer());
+        $this->assertStringContainsString('test [pending]', $output->getBuffer());
+    }
+}

--- a/tests/Command/Migration/UpCommandTest.php
+++ b/tests/Command/Migration/UpCommandTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Migration;
+
+use Cycle\Database\Config\DatabaseConfig;
+use Cycle\Database\Config\SQLite\MemoryConnectionConfig;
+use Cycle\Database\Config\SQLiteDriverConfig;
+use Cycle\Database\DatabaseManager;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\Migrator;
+use Cycle\Migrations\RepositoryInterface;
+use Cycle\Migrations\State;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Migration\UpCommand;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeMigration;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeOutput;
+
+final class UpCommandTest extends TestCase
+{
+    public function testExecuteWithoutMigrations(): void
+    {
+        $config = new MigrationConfig();
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->once())->method('getMigrations')->willReturn([]);
+
+        $migrator = new Migrator(
+            $config,
+            $this->createMock(DatabaseProviderInterface::class),
+            $repository
+        );
+
+        $output = new FakeOutput();
+        $command = new UpCommand(
+            new CycleDependencyProxy(new SimpleContainer([
+                Migrator::class => $migrator,
+                MigrationConfig::class => $config,
+            ])),
+            $this->createMock(EventDispatcherInterface::class)
+        );
+        $code = $command->run(new ArrayInput([]), $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('No migration found for execute', $output->getBuffer());
+    }
+
+    public function testExecute(): void
+    {
+        $config = new MigrationConfig(['safe' => true]);
+
+        $migration = new FakeMigration();
+        $migration = $migration->withState(new State('test', new \DateTimeImmutable(), State::STATUS_PENDING));
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $repository->expects($this->exactly(3))->method('getMigrations')->willReturn([$migration]);
+
+        $migrator = new Migrator(
+            new MigrationConfig(),
+            new DatabaseManager(new DatabaseConfig([
+                'default' => 'default',
+                'databases' => ['default' => ['connection' => 'sqlite']],
+                'connections' => [
+                    'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+                ]
+            ])), $repository);
+        $migrator->configure();
+
+        $output = new FakeOutput();
+        $command = new UpCommand(
+            new CycleDependencyProxy(new SimpleContainer([
+                Migrator::class => $migrator,
+                MigrationConfig::class => $config,
+            ])),
+            $this->createMock(EventDispatcherInterface::class)
+        );
+
+        $input = new ArrayInput([]);
+        $input->setInteractive(false);
+        $code = $command->run($input, $output);
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Migration to be applied:', $output->getBuffer());
+        $this->assertStringContainsString('test: executed', $output->getBuffer());
+    }
+}

--- a/tests/Command/Migration/UpCommandTest.php
+++ b/tests/Command/Migration/UpCommandTest.php
@@ -69,8 +69,10 @@ final class UpCommandTest extends TestCase
                 'databases' => ['default' => ['connection' => 'sqlite']],
                 'connections' => [
                     'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
-                ]
-            ])), $repository);
+                ],
+            ])),
+            $repository
+        );
         $migrator->configure();
 
         $output = new FakeOutput();

--- a/tests/Command/Schema/SchemaClearCommandTest.php
+++ b/tests/Command/Schema/SchemaClearCommandTest.php
@@ -13,7 +13,7 @@ use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
 use Yiisoft\Yii\Cycle\Command\Schema\SchemaClearCommand;
 use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
 
-final class SchemaClearBaseCommandTest extends TestCase
+final class SchemaClearCommandTest extends TestCase
 {
     public function testExecute(): void
     {

--- a/tests/Command/Schema/SchemaPhpCommandTest.php
+++ b/tests/Command/Schema/SchemaPhpCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Schema;
+
+use Cycle\ORM\SchemaInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Cycle\Command\CycleDependencyProxy;
+use Yiisoft\Yii\Cycle\Command\Schema\SchemaPhpCommand;
+use Yiisoft\Yii\Cycle\Tests\Command\Stub\FakeOutput;
+
+final class SchemaPhpCommandTest extends TestCase
+{
+    private FakeOutput $output;
+
+    protected function setUp(): void
+    {
+        $this->output = new FakeOutput();
+    }
+
+    public function testExecuteWithoutFile(): void
+    {
+        $schema = $this->createMock(SchemaInterface::class);
+        $schema->expects($this->any())->method('getRoles')->willReturn(['foo', 'bar']);
+        $schema->expects($this->any())->method('define')->willReturnCallback(
+            fn (string $role, int $property): ?string => $property === SchemaInterface::ROLE ? $role : null
+        );
+
+        $container = new SimpleContainer([SchemaInterface::class => $schema]);
+        $promise = new CycleDependencyProxy($container);
+        $command = new SchemaPhpCommand(new Aliases(), $promise);
+
+        $code = $command->run(new ArrayInput([]), $this->output);
+        $result = $this->output->getBuffer();
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString('Schema::ROLE => \'foo\'', $result);
+        $this->assertStringContainsString('Schema::ROLE => \'bar\'', $result);
+    }
+
+    public function testExecuteWithFile(): void
+    {
+        $file = \dirname(__DIR__) . '/Stub/schema.php';
+
+        $schema = $this->createMock(SchemaInterface::class);
+        $schema->expects($this->any())->method('getRoles')->willReturn(['foo', 'bar']);
+        $schema->expects($this->any())->method('define')->willReturnCallback(
+            fn (string $role, int $property): ?string => $property === SchemaInterface::ROLE ? $role : null
+        );
+
+        $container = new SimpleContainer([SchemaInterface::class => $schema]);
+        $promise = new CycleDependencyProxy($container);
+        $command = new SchemaPhpCommand(new Aliases(), $promise);
+
+        $code = $command->run(new ArrayInput(['file' => $file]), $this->output);
+        $result = $this->output->getBuffer();
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString(sprintf('Destination: %s', $file), $result);
+
+        $this->assertStringContainsString('Schema::ROLE => \'foo\'', file_get_contents($file));
+        $this->assertStringContainsString('Schema::ROLE => \'bar\'', file_get_contents($file));
+
+        \unlink($file);
+    }
+
+    public function testExecuteWithFileAndAlias(): void
+    {
+        $file = \dirname(__DIR__) . '/Stub/alias-schema.php';
+
+        $schema = $this->createMock(SchemaInterface::class);
+        $schema->expects($this->any())->method('getRoles')->willReturn(['foo', 'bar']);
+        $schema->expects($this->any())->method('define')->willReturnCallback(
+            fn (string $role, int $property): ?string => $property === SchemaInterface::ROLE ? $role : null
+        );
+
+        $container = new SimpleContainer([SchemaInterface::class => $schema]);
+        $promise = new CycleDependencyProxy($container);
+        $command = new SchemaPhpCommand(new Aliases([
+            '@test' => \dirname(__DIR__) . '/Stub',
+        ]), $promise);
+
+        $code = $command->run(new ArrayInput(['file' => '@test/alias-schema.php']), $this->output);
+        $result = $this->output->getBuffer();
+
+        $this->assertSame(ExitCode::OK, $code);
+        $this->assertStringContainsString(sprintf('Destination: %s', $file), $result);
+
+        $this->assertStringContainsString('Schema::ROLE => \'foo\'', file_get_contents($file));
+        $this->assertStringContainsString('Schema::ROLE => \'bar\'', file_get_contents($file));
+
+        \unlink($file);
+    }
+}

--- a/tests/Command/Stub/FakeMigration.php
+++ b/tests/Command/Stub/FakeMigration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Stub;
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Stub;
+
+use Cycle\Migrations\Migration;
+
+final class FakeMigration extends Migration
+{
+    public function up(): void
+    {
+    }
+
+    public function down(): void
+    {
+    }
+}

--- a/tests/Command/Stub/FakeOutput.php
+++ b/tests/Command/Stub/FakeOutput.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Command\Stub;
+
+use Symfony\Component\Console\Output\Output;
+
+final class FakeOutput extends Output
+{
+    private string $buffer = '';
+
+    protected function doWrite(string $message, bool $newline): void
+    {
+        $this->buffer .= $message;
+
+        if ($newline) {
+            $this->buffer .= \PHP_EOL;
+        }
+    }
+
+    public function getBuffer(): string
+    {
+        return $this->buffer;
+    }
+}

--- a/tests/Feature/Data/Reader/EntityReaderTest.php
+++ b/tests/Feature/Data/Reader/EntityReaderTest.php
@@ -174,6 +174,7 @@ final class EntityReaderTest extends BaseData
 
         $reader = new EntityReader($this->select('user'));
         $ref = new \ReflectionProperty(EntityReader::class, 'filterHandlers');
+        $ref->setAccessible(true);
 
         self::assertEquals($default, $ref->getValue($reader));
         $reader = $reader->withFilterHandlers($custom);

--- a/tests/Feature/Data/Reader/EntityReaderTest.php
+++ b/tests/Feature/Data/Reader/EntityReaderTest.php
@@ -2,10 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Cycle\Tests\Feature\Data;
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader;
 
+use Yiisoft\Data\Reader\Filter\Equals;
 use Yiisoft\Data\Reader\Sort;
 use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Data\Reader\FilterHandler;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
 
 /**
  * @covers \Yiisoft\Yii\Cycle\Data\Reader\EntityReader
@@ -112,6 +115,15 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
+     * Test {@see EntityReader::withLimit()}
+     */
+    public function testLimitException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        (new EntityReader($this->select('user')))->withLimit(-1);
+    }
+
+    /**
      * Test {@see EntityReader::withLimit()} and {@see EntityReader::withOffset()}
      */
     public function testLimitOffset(): void
@@ -126,6 +138,58 @@ final class EntityReaderTest extends BaseData
         self::assertEquals(
             [(object)self::FIXTURES_USER[1], (object)self::FIXTURES_USER[2]],
             $reader->read(),
+        );
+    }
+
+    /**
+     * Test {@see EntityReader::withFilter()}
+     */
+    public function testFilter(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter(new Equals('id', 2));
+
+        self::assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
+    }
+
+    /**
+     * Test {@see EntityReader::withFilterHandlers()}
+     */
+    public function testFilterHandlers(): void
+    {
+        $default = [
+            'and' => new FilterHandler\AllHandler(),
+            'or' => new FilterHandler\AnyHandler(),
+            '=' => new FilterHandler\EqualsHandler(),
+            '>' => new FilterHandler\GreaterThanHandler(),
+            '>=' => new FilterHandler\GreaterThanOrEqualHandler(),
+            'in' => new FilterHandler\InHandler(),
+            '<' => new FilterHandler\LessThanHandler(),
+            '<=' => new FilterHandler\LessThanOrEqualHandler(),
+            'like' => new FilterHandler\LikeHandler(),
+        ];
+        $custom = $this->createMock(FilterHandler\CompareHandler::class);
+        $custom->method('getOperator')->willReturn('custom');
+
+        $reader = new EntityReader($this->select('user'));
+        $ref = new \ReflectionProperty(EntityReader::class, 'filterHandlers');
+
+        self::assertEquals($default, $ref->getValue($reader));
+        $reader = $reader->withFilterHandlers($custom);
+        self::assertEquals($default + ['custom' => $custom], $ref->getValue($reader));
+    }
+
+    public function testGetSql(): void
+    {
+        $expected = 'SELECT "user"."id" AS "c0", "user"."email" AS "c1", "user"."balance" AS "c2"
+            FROM "user" AS "user" LIMIT 2 OFFSET 1';
+
+        $reader = (new EntityReader($this->select('user')))->withLimit(2)->withOffset(1);
+
+        self::assertEquals(
+            \preg_replace('/\s+/', '', $expected),
+            \preg_replace('/\s+/', '', $reader->getSql())
         );
     }
 }

--- a/tests/Feature/Data/Reader/EntityReaderTest.php
+++ b/tests/Feature/Data/Reader/EntityReaderTest.php
@@ -11,34 +11,30 @@ use Yiisoft\Yii\Cycle\Data\Reader\FilterHandler;
 use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
 
 /**
- * @covers \Yiisoft\Yii\Cycle\Data\Reader\EntityReader
+ * @coversDefaultClass \Yiisoft\Yii\Cycle\Data\Reader\EntityReader
  */
 final class EntityReaderTest extends BaseData
 {
     /**
-     * Test {@see EntityReader::readOne()}
+     * @covers ::readOne
      */
     public function testReadOne(): void
     {
         $this->fillFixtures();
 
-        $reader = new EntityReader(
-            $this->select('user'),
-        );
+        $reader = new EntityReader($this->select('user'));
 
         self::assertEquals(self::FIXTURES_USER[0], (array)$reader->readOne());
     }
 
     /**
-     * Test {@see EntityReader::read()}
+     * @covers ::read
      */
     public function testRead(): void
     {
         $this->fillFixtures();
 
-        $reader = new EntityReader(
-            $this->select('user'),
-        );
+        $reader = new EntityReader($this->select('user'));
 
         $result = $reader->read();
         self::assertEquals(
@@ -48,7 +44,7 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::withSort()}
+     * @covers ::withSort
      */
     public function testWithSort(): void
     {
@@ -69,21 +65,20 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::count()}
+     * @covers ::count
      */
     public function testCount(): void
     {
         $this->fillFixtures();
 
-        $reader = new EntityReader(
-            $this->select('user'),
-        );
+        $reader = new EntityReader($this->select('user'));
 
         self::assertSame(count(self::FIXTURES_USER), $reader->count());
     }
 
     /**
-     * Test {@see EntityReader::count()} with limit. The limit option mustn't affect the count result.
+     * @covers ::count
+     * The limit option mustn't affect the count result.
      */
     public function testCountWithLimit(): void
     {
@@ -97,7 +92,7 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::withLimit()}
+     * @covers ::withLimit
      */
     public function testLimit(): void
     {
@@ -115,7 +110,7 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::withLimit()}
+     * @covers ::withLimit
      */
     public function testLimitException(): void
     {
@@ -124,7 +119,8 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::withLimit()} and {@see EntityReader::withOffset()}
+     * @covers ::withLimit
+     * @covers ::withOffset
      */
     public function testLimitOffset(): void
     {
@@ -142,7 +138,7 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::withFilter()}
+     * @covers ::withFilter
      */
     public function testFilter(): void
     {
@@ -154,7 +150,7 @@ final class EntityReaderTest extends BaseData
     }
 
     /**
-     * Test {@see EntityReader::withFilterHandlers()}
+     * @covers ::withFilterHandlers
      */
     public function testFilterHandlers(): void
     {
@@ -181,6 +177,9 @@ final class EntityReaderTest extends BaseData
         self::assertEquals($default + ['custom' => $custom], $ref->getValue($reader));
     }
 
+    /**
+     * @covers ::getSql
+     */
     public function testGetSql(): void
     {
         $expected = 'SELECT "user"."id" AS "c0", "user"."email" AS "c1", "user"."balance" AS "c2"

--- a/tests/Feature/Data/Reader/FilterHandler/AllHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/AllHandlerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\All;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class AllHandlerTest extends BaseData
+{
+    public function testAllHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new All())->withCriteriaArray([
+            ['=', 'balance', '100.0'],
+            ['=', 'email', 'seed@beat'],
+        ]));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[2]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/AnyHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/AnyHandlerTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\Any;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class AnyHandlerTest extends BaseData
+{
+    public function testAnyHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new Any())->withCriteriaArray([
+            ['=', 'id', 2],
+            ['=', 'id', 3],
+        ]));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[1], (object)self::FIXTURES_USER[2]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/EqualsHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/EqualsHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\Equals;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class EqualsHandlerTest extends BaseData
+{
+    public function testEqualsHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new Equals('id', 2)));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/EqualsHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/EqualsHandlerTest.php
@@ -14,7 +14,7 @@ final class EqualsHandlerTest extends BaseData
     {
         $this->fillFixtures();
 
-        $reader = (new EntityReader($this->select('user')))->withFilter((new Equals('id', 2)));
+        $reader = (new EntityReader($this->select('user')))->withFilter(new Equals('id', 2));
 
         $this->assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/GreaterThanHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/GreaterThanHandlerTest.php
@@ -14,7 +14,7 @@ final class GreaterThanHandlerTest extends BaseData
     {
         $this->fillFixtures();
 
-        $reader = (new EntityReader($this->select('user')))->withFilter((new GreaterThan('balance', 499)));
+        $reader = (new EntityReader($this->select('user')))->withFilter(new GreaterThan('balance', 499));
 
         $this->assertEquals([(object)self::FIXTURES_USER[3]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/GreaterThanHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/GreaterThanHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\GreaterThan;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class GreaterThanHandlerTest extends BaseData
+{
+    public function testGreaterThanHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new GreaterThan('balance', 499)));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[3]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/GreaterThanOrEqualHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/GreaterThanOrEqualHandlerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\GreaterThanOrEqual;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class GreaterThanOrEqualHandlerTest extends BaseData
+{
+    public function testGreaterThanOrEqualHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))
+            ->withFilter((new GreaterThanOrEqual('balance', 500)));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[3]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/GreaterThanOrEqualHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/GreaterThanOrEqualHandlerTest.php
@@ -15,7 +15,7 @@ final class GreaterThanOrEqualHandlerTest extends BaseData
         $this->fillFixtures();
 
         $reader = (new EntityReader($this->select('user')))
-            ->withFilter((new GreaterThanOrEqual('balance', 500)));
+            ->withFilter(new GreaterThanOrEqual('balance', 500));
 
         $this->assertEquals([(object)self::FIXTURES_USER[3]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/InHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/InHandlerTest.php
@@ -14,7 +14,7 @@ final class InHandlerTest extends BaseData
     {
         $this->fillFixtures();
 
-        $reader = (new EntityReader($this->select('user')))->withFilter((new In('id', [2, 3])));
+        $reader = (new EntityReader($this->select('user')))->withFilter(new In('id', [2, 3]));
 
         $this->assertEquals([(object)self::FIXTURES_USER[1], (object)self::FIXTURES_USER[2]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/InHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/InHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\In;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class InHandlerTest extends BaseData
+{
+    public function testInHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new In('id', [2, 3])));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[1], (object)self::FIXTURES_USER[2]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/LessThanHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/LessThanHandlerTest.php
@@ -14,7 +14,7 @@ final class LessThanHandlerTest extends BaseData
     {
         $this->fillFixtures();
 
-        $reader = (new EntityReader($this->select('user')))->withFilter((new LessThan('balance', 1.1)));
+        $reader = (new EntityReader($this->select('user')))->withFilter(new LessThan('balance', 1.1));
 
         $this->assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/LessThanHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/LessThanHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\LessThan;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class LessThanHandlerTest extends BaseData
+{
+    public function testLessThanHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new LessThan('balance', 1.1)));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/LessThanOrEqualHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/LessThanOrEqualHandlerTest.php
@@ -14,7 +14,7 @@ final class LessThanOrEqualHandlerTest extends BaseData
     {
         $this->fillFixtures();
 
-        $reader = (new EntityReader($this->select('user')))->withFilter((new LessThanOrEqual('balance', 1.0)));
+        $reader = (new EntityReader($this->select('user')))->withFilter(new LessThanOrEqual('balance', 1.0));
 
         $this->assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/LessThanOrEqualHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/LessThanOrEqualHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\LessThanOrEqual;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class LessThanOrEqualHandlerTest extends BaseData
+{
+    public function testLessThanOrEqualHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new LessThanOrEqual('balance', 1.0)));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[1]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Reader/FilterHandler/LikeHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/LikeHandlerTest.php
@@ -14,7 +14,7 @@ final class LikeHandlerTest extends BaseData
     {
         $this->fillFixtures();
 
-        $reader = (new EntityReader($this->select('user')))->withFilter((new Like('email', 'seed@%')));
+        $reader = (new EntityReader($this->select('user')))->withFilter(new Like('email', 'seed@%'));
 
         $this->assertEquals([(object)self::FIXTURES_USER[2]], $reader->read());
     }

--- a/tests/Feature/Data/Reader/FilterHandler/LikeHandlerTest.php
+++ b/tests/Feature/Data/Reader/FilterHandler/LikeHandlerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Reader\FilterHandler;
+
+use Yiisoft\Data\Reader\Filter\Like;
+use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
+
+final class LikeHandlerTest extends BaseData
+{
+    public function testLikeHandler(): void
+    {
+        $this->fillFixtures();
+
+        $reader = (new EntityReader($this->select('user')))->withFilter((new Like('email', 'seed@%')));
+
+        $this->assertEquals([(object)self::FIXTURES_USER[2]], $reader->read());
+    }
+}

--- a/tests/Feature/Data/Writer/EntityWriterTest.php
+++ b/tests/Feature/Data/Writer/EntityWriterTest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Cycle\Tests\Feature\Data;
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Data\Writer;
 
 use Cycle\ORM\EntityManagerInterface;
 use Yiisoft\Yii\Cycle\Data\Reader\EntityReader;
 use Yiisoft\Yii\Cycle\Data\Writer\EntityWriter;
+use Yiisoft\Yii\Cycle\Tests\Feature\Data\BaseData;
 
 /**
  * @covers \Yiisoft\Yii\Cycle\Data\Writer\EntityWriter

--- a/tests/Feature/Factory/MigratorFactoryTest.php
+++ b/tests/Feature/Factory/MigratorFactoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Feature\Factory;
+
+use Cycle\Database\Config\DatabaseConfig;
+use Cycle\Database\Config\SQLite\MemoryConnectionConfig;
+use Cycle\Database\Config\SQLiteDriverConfig;
+use Cycle\Database\DatabaseManager;
+use Cycle\Migrations\Config\MigrationConfig;
+use Cycle\Migrations\FileRepository;
+use PHPUnit\Framework\TestCase;
+use Spiral\Core\FactoryInterface;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Cycle\Factory\MigratorFactory;
+
+final class MigratorFactoryTest extends TestCase
+{
+    public function testInvoke(): void
+    {
+        $defaultConfig = new MigrationConfig();
+
+        $db = new DatabaseManager(new DatabaseConfig([
+            'default' => 'default',
+            'databases' => ['default' => ['connection' => 'sqlite']],
+            'connections' => [
+                'sqlite' => new SQLiteDriverConfig(connection: new MemoryConnectionConfig()),
+            ],
+        ]));
+
+        $this->assertFalse($db->database('default')->hasTable($defaultConfig->getTable()));
+
+        $factory = new MigratorFactory();
+        $migrator = $factory(new SimpleContainer([
+            MigrationConfig::class => $defaultConfig,
+            DatabaseManager::class => $db,
+            FactoryInterface::class => $this->createMock(FactoryInterface::class)
+        ]));
+
+        $configRef = new \ReflectionProperty($migrator, 'config');
+        $configRef->setAccessible(true);
+
+        $dbalRef = new \ReflectionProperty($migrator, 'dbal');
+        $dbalRef->setAccessible(true);
+
+        $repositoryRef = new \ReflectionProperty($migrator, 'repository');
+        $repositoryRef->setAccessible(true);
+
+        $this->assertTrue($db->database('default')->hasTable($defaultConfig->getTable()));
+        $this->assertSame($defaultConfig, $configRef->getValue($migrator));
+        $this->assertSame($db, $dbalRef->getValue($migrator));
+        $this->assertInstanceOf(FileRepository::class, $repositoryRef->getValue($migrator));
+    }
+}

--- a/tests/Feature/Factory/MigratorFactoryTest.php
+++ b/tests/Feature/Factory/MigratorFactoryTest.php
@@ -35,7 +35,7 @@ final class MigratorFactoryTest extends TestCase
         $migrator = $factory(new SimpleContainer([
             MigrationConfig::class => $defaultConfig,
             DatabaseManager::class => $db,
-            FactoryInterface::class => $this->createMock(FactoryInterface::class)
+            FactoryInterface::class => $this->createMock(FactoryInterface::class),
         ]));
 
         $configRef = new \ReflectionProperty($migrator, 'config');

--- a/tests/Unit/Factory/CycleDynamicFactoryTest.php
+++ b/tests/Unit/Factory/CycleDynamicFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Unit\Factory;
+
+use Cycle\Database\Config\ConnectionConfig;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Injector\Injector;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Cycle\Factory\CycleDynamicFactory;
+use Yiisoft\Yii\Cycle\Tests\Unit\Stub\FakeDriverConfig;
+
+final class CycleDynamicFactoryTest extends TestCase
+{
+    public function testMake(): void
+    {
+        $factory = new CycleDynamicFactory(new Injector(new SimpleContainer([
+            ConnectionConfig::class => $this->createMock(ConnectionConfig::class)
+        ])));
+
+        $this->assertInstanceOf(
+            FakeDriverConfig::class,
+            $factory->make(FakeDriverConfig::class, ['driver' => 'foo'])
+        );
+    }
+}

--- a/tests/Unit/Factory/CycleDynamicFactoryTest.php
+++ b/tests/Unit/Factory/CycleDynamicFactoryTest.php
@@ -16,7 +16,7 @@ final class CycleDynamicFactoryTest extends TestCase
     public function testMake(): void
     {
         $factory = new CycleDynamicFactory(new Injector(new SimpleContainer([
-            ConnectionConfig::class => $this->createMock(ConnectionConfig::class)
+            ConnectionConfig::class => $this->createMock(ConnectionConfig::class),
         ])));
 
         $this->assertInstanceOf(

--- a/tests/Unit/Factory/MigrationConfigFactoryTest.php
+++ b/tests/Unit/Factory/MigrationConfigFactoryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Unit\Factory;
+
+use Cycle\Migrations\Config\MigrationConfig;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Aliases\Aliases;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Cycle\Factory\MigrationConfigFactory;
+
+final class MigrationConfigFactoryTest extends TestCase
+{
+    public function testInvokeWithoutAlias(): void
+    {
+        $factory = new MigrationConfigFactory(['directory' => 'test/foo/bar']);
+
+        $this->assertEquals(
+            new MigrationConfig(['directory' => 'test/foo/bar']),
+            $factory(new SimpleContainer([Aliases::class => new Aliases()]))
+        );
+    }
+
+    public function testInvoke(): void
+    {
+        $factory = new MigrationConfigFactory(['directory' => '@test/foo/bar']);
+
+        $this->assertEquals(
+            new MigrationConfig(['directory' => 'src/test/app/foo/bar']),
+            $factory(new SimpleContainer([Aliases::class => new Aliases(['@test' => 'src/test/app'])]))
+        );
+    }
+}

--- a/tests/Unit/Factory/RepositoryContainerTest.php
+++ b/tests/Unit/Factory/RepositoryContainerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Unit\Factory;
+
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\RepositoryInterface;
+use Cycle\ORM\Schema;
+use Cycle\ORM\Select;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Test\Support\Container\SimpleContainer;
+use Yiisoft\Yii\Cycle\Exception\NotFoundException;
+use Yiisoft\Yii\Cycle\Exception\NotInstantiableClassException;
+use Yiisoft\Yii\Cycle\Factory\RepositoryContainer;
+use Yiisoft\Yii\Cycle\Tests\Unit\Stub\FakeEntity;
+use Yiisoft\Yii\Cycle\Tests\Unit\Stub\FakeRepository;
+
+final class RepositoryContainerTest extends TestCase
+{
+    private Schema $schema;
+
+    protected function setUp(): void
+    {
+        $this->schema = new Schema([
+            'foo' => [
+                Schema::ENTITY => FakeEntity::class,
+                Schema::REPOSITORY => FakeRepository::class,
+            ]
+        ]);
+    }
+
+    public function testGetNotFoundException(): void
+    {
+        $orm = $this->createMock(ORMInterface::class);
+        $orm->expects($this->once())->method('getSchema')->willReturn(new Schema([]));
+
+        $container = new RepositoryContainer(new SimpleContainer([ORMInterface::class => $orm]));
+
+        $this->expectException(NotFoundException::class);
+        $container->get(FakeRepository::class);
+    }
+
+    public function testGetNotInstantiableClassException(): void
+    {
+        $container = new RepositoryContainer(new SimpleContainer([
+            ORMInterface::class => $this->createMock(ORMInterface::class)
+        ]));
+
+        $this->expectException(NotInstantiableClassException::class);
+        $container->get('foo');
+    }
+
+    public function testMakeAndGet(): void
+    {
+        $orm = $this->createMock(ORMInterface::class);
+        $orm->expects($this->once())->method('getSchema')->willReturn($this->schema);
+        $orm->expects($this->once())
+            ->method('getRepository')
+            ->with('foo')
+            ->willReturn(new FakeRepository($this->createMock(Select::class)));
+
+        $container = new RepositoryContainer(new SimpleContainer([ORMInterface::class => $orm]));
+        $instancesRef = new \ReflectionProperty($container, 'instances');
+        $instancesRef->setAccessible(true);
+
+        $this->assertSame([], $instancesRef->getValue($container));
+        $this->assertInstanceOf(FakeRepository::class, $container->get(FakeRepository::class));
+    }
+
+    public function testGetFromInstances(): void
+    {
+        $orm = $this->createMock(ORMInterface::class);
+        $orm->expects($this->once())->method('getSchema')->willReturn($this->schema);
+        $orm->expects($this->once())
+            ->method('getRepository')
+            ->with('foo')
+            ->willReturn(new FakeRepository($this->createMock(Select::class)));
+
+        $container = new RepositoryContainer(new SimpleContainer([ORMInterface::class => $orm]));
+        $instancesRef = new \ReflectionProperty($container, 'instances');
+        $instancesRef->setAccessible(true);
+
+        $this->assertSame([], $instancesRef->getValue($container));
+        $repository = $container->get(FakeRepository::class);
+        $this->assertInstanceOf(FakeRepository::class, $repository);
+
+        $this->assertSame([FakeRepository::class => $repository], $instancesRef->getValue($container));
+        $this->assertSame($repository, $container->get(FakeRepository::class));
+    }
+
+    public function testHasNonInterface(): void
+    {
+        $orm = $this->createMock(ORMInterface::class);
+        $orm->expects($this->never())->method('getSchema');
+
+        $container = new RepositoryContainer(new SimpleContainer([ORMInterface::class => $orm]));
+
+        $this->assertFalse($container->has('foo'));
+    }
+
+    public function testHas(): void
+    {
+        $orm = $this->createMock(ORMInterface::class);
+        $orm->expects($this->once())->method('getSchema')->willReturn($this->schema);
+
+        $container = new RepositoryContainer(new SimpleContainer([ORMInterface::class => $orm]));
+
+        $repository = $this->createMock(RepositoryInterface::class);
+        $this->assertTrue($container->has(FakeRepository::class));
+        $this->assertFalse($container->has($repository::class));
+    }
+}

--- a/tests/Unit/Factory/RepositoryContainerTest.php
+++ b/tests/Unit/Factory/RepositoryContainerTest.php
@@ -26,7 +26,7 @@ final class RepositoryContainerTest extends TestCase
             'foo' => [
                 Schema::ENTITY => FakeEntity::class,
                 Schema::REPOSITORY => FakeRepository::class,
-            ]
+            ],
         ]);
     }
 
@@ -44,7 +44,7 @@ final class RepositoryContainerTest extends TestCase
     public function testGetNotInstantiableClassException(): void
     {
         $container = new RepositoryContainer(new SimpleContainer([
-            ORMInterface::class => $this->createMock(ORMInterface::class)
+            ORMInterface::class => $this->createMock(ORMInterface::class),
         ]));
 
         $this->expectException(NotInstantiableClassException::class);

--- a/tests/Unit/Stub/FakeEntity.php
+++ b/tests/Unit/Stub/FakeEntity.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Unit\Stub;
+
+final class FakeEntity
+{
+}

--- a/tests/Unit/Stub/FakeRepository.php
+++ b/tests/Unit/Stub/FakeRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Cycle\Tests\Unit\Stub;
+
+use Cycle\ORM\Select\Repository;
+
+final class FakeRepository extends Repository
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌

Part of #22 

## What was changed

1. Unit tests have been added to the files that had a low coverage level according to the coverage report: https://scrutinizer-ci.com/g/yiisoft/yii-cycle/code-structure/master/code-coverage/src/
2. In the console command `Yiisoft\Yii\Cycle\Command\Migration\DownCommand` the unused variable **$exist** was removed and the result of the **rollback** method was added to the **$migration** variable. This method returns the migration to which the **rollback** was applied and it contains the new status.
3. In the console command `Yiisoft\Yii\Cycle\Command\Migration\GenerateCommand` the retrieval of the helper has been moved to the block with the condition **$input->isInteractive()**, as it is only used within it.
4. In the `Yiisoft\Yii\Cycle\Factory\RepositoryContainer` class, the private property **rootContainer** has been removed. It was only set in the constructor and was not used anywhere else.
