### PR TITLE
Remove phpunit 10, fix config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "require-dev": {
         "cycle/entity-behavior": "^1.0",
         "jetbrains/phpstorm-attributes": "^1.0",
-        "phpunit/phpunit": "^9.6|^10",
+        "phpunit/phpunit": "^9.6",
         "roave/infection-static-analysis-plugin": "^1.25",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.30|^5.7",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     stopOnFailure="false"
     executionOrder="random"
     resolveDependencies="true"
-    cacheDirectory=".phpunit.cache"
 >
     <php>
         <ini name="error_reporting" value="-1"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | #180 

PHPUnit 10 with the config from PHPUnit 9 breaks mutation testing. But we can't drop PHPUnit 9 support due to support for PHP 8.0